### PR TITLE
PW-2 / 스플래시 스크린 구현

### DIFF
--- a/components/atoms/LoadingCircle/LoadingCircle.stories.tsx
+++ b/components/atoms/LoadingCircle/LoadingCircle.stories.tsx
@@ -1,0 +1,13 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { LoadingCircle } from "./LoadingCircle";
+
+export default {
+    title: "Components/Atoms/LoadingCircle",
+    component: LoadingCircle,
+    argTypes: {},
+} as ComponentMeta<typeof LoadingCircle>;
+
+export const Default: ComponentStory<typeof LoadingCircle> = (args) => {
+    return <LoadingCircle {...args} />;
+};

--- a/components/atoms/LoadingCircle/LoadingCircle.styles.ts
+++ b/components/atoms/LoadingCircle/LoadingCircle.styles.ts
@@ -5,8 +5,11 @@ const circleAnimation = keyframes`
   0% {
     transform: scale(1);
   }
-  10% {
+  5% {
     transform: scale(1);
+  }
+  10% {
+    transform: scale(0.9);
   }
   50% {
     transform: scale(3);

--- a/components/atoms/LoadingCircle/LoadingCircle.styles.ts
+++ b/components/atoms/LoadingCircle/LoadingCircle.styles.ts
@@ -1,0 +1,63 @@
+import { keyframes } from "@emotion/react";
+import styled from "@emotion/styled";
+
+const circleAnimation = keyframes`
+  0% {
+    transform: scale(1);
+  }
+  10% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(3);
+  }
+  65% {
+    transform: scale(3);
+  }
+  70% {
+    transform: scale(2.8);
+  }
+  100% {
+    transform: scale(50);
+  }
+`;
+
+const percentAnimation = keyframes`
+    0% {
+    transform: scale(1);
+  }
+  10% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(0.6);
+    opacity: 100%;
+  }
+  70% {
+    transform: scale(0.6);
+    opacity: 0%;
+  }
+`;
+
+export const Circle = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    width: 3rem;
+    height: 3rem;
+
+    border-radius: 50%;
+    background-color: ${({ theme }) => theme.colors.darkSlateGreen};
+
+    animation: 6s ease-in-out ${circleAnimation};
+    animation-fill-mode: forwards;
+`;
+
+export const Percentage = styled.div`
+    color: ${({ theme }) => theme.colors.white};
+    font-size: 0.5rem;
+
+    animation: 6s ease-in-out ${percentAnimation};
+    animation-fill-mode: forwards;
+`;

--- a/components/atoms/LoadingCircle/LoadingCircle.tsx
+++ b/components/atoms/LoadingCircle/LoadingCircle.tsx
@@ -16,7 +16,7 @@ export function LoadingCircle({ ...props }) {
                     clearInterval(percentUp);
                 }
             }, 40);
-        }, 500);
+        }, 700);
     }, []);
 
     useEffect(() => {

--- a/components/atoms/LoadingCircle/LoadingCircle.tsx
+++ b/components/atoms/LoadingCircle/LoadingCircle.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from "react";
+import * as S from "./LoadingCircle.styles";
+
+export function LoadingCircle({ ...props }) {
+    const [percentage, setPercentage] = useState(0);
+    const [percentVisible, setPercentVisible] = useState(true);
+
+    useEffect(() => {
+        let percent = 0;
+        const set = setTimeout(() => {
+            const percentUp = setInterval(() => {
+                percent += 2;
+                setPercentage(percent);
+
+                if (percent === 100) {
+                    clearInterval(percentUp);
+                }
+            }, 40);
+        }, 500);
+    }, []);
+
+    useEffect(() => {
+        if (percentage === 100) {
+            setTimeout(() => setPercentVisible(false), 1500);
+        }
+    }, [percentage]);
+
+    return (
+        <S.Circle className={"visible"}>
+            <S.Percentage
+                style={{
+                    display: `${percentVisible ? "block" : "none"}`,
+                }}
+            >{`${percentage}%`}</S.Percentage>
+        </S.Circle>
+    );
+}

--- a/components/atoms/LoadingCircle/index.ts
+++ b/components/atoms/LoadingCircle/index.ts
@@ -1,0 +1,1 @@
+export { LoadingCircle } from "./LoadingCircle";

--- a/components/features/SplashCard/SplashCard.stories.tsx
+++ b/components/features/SplashCard/SplashCard.stories.tsx
@@ -1,0 +1,13 @@
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+
+import { SplashCard } from "./SplashCard";
+
+export default {
+    title: "Components/Features/SplashCard",
+    component: SplashCard,
+    argTypes: {},
+} as ComponentMeta<typeof SplashCard>;
+
+export const Default: ComponentStory<typeof SplashCard> = (args) => {
+    return <SplashCard {...args} />;
+};

--- a/components/features/SplashCard/SplashCard.styles.ts
+++ b/components/features/SplashCard/SplashCard.styles.ts
@@ -1,4 +1,17 @@
 import styled from "@emotion/styled";
+import { keyframes } from "@emotion/react";
+
+const cardAnimation = keyframes`
+  80% {
+    transform: translateY(0);
+  }
+  85% {
+    transform: translateY(10px);
+  }
+  100% {
+    transform: translateY(-3500px);
+  }
+`;
 
 export const Container = styled.div`
     display: flex;
@@ -14,6 +27,9 @@ export const Container = styled.div`
     color: white;
 
     z-index: 1000;
+
+    animation: 8s ease-in-out ${cardAnimation};
+    animation-fill-mode: forwards;
 `;
 
 export const TextContainer = styled.div`

--- a/components/features/SplashCard/SplashCard.styles.ts
+++ b/components/features/SplashCard/SplashCard.styles.ts
@@ -25,6 +25,7 @@ export const Container = styled.div`
     height: 100vh;
 
     color: white;
+    background-color: white;
 
     z-index: 1000;
 

--- a/components/features/SplashCard/SplashCard.styles.ts
+++ b/components/features/SplashCard/SplashCard.styles.ts
@@ -1,0 +1,43 @@
+import styled from "@emotion/styled";
+
+export const Container = styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: fixed;
+    top: 0;
+    left: 0;
+
+    width: 100vw;
+    height: 100vh;
+
+    color: white;
+
+    z-index: 1000;
+`;
+
+export const TextContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
+    position: absolute;
+    left: 0;
+    top: 0;
+
+    width: 100%;
+    height: 100%;
+    padding: 5rem;
+`;
+
+export const Desc = styled.div`
+    font-size: 0.75rem;
+    font-weight: 200;
+    text-align: center;
+`;
+
+export const Name = styled.div`
+    font-size: 10rem;
+    font-weight: 900;
+    text-align: center;
+`;

--- a/components/features/SplashCard/SplashCard.tsx
+++ b/components/features/SplashCard/SplashCard.tsx
@@ -1,0 +1,24 @@
+import { LoadingCircle } from "components/atoms/LoadingCircle";
+import * as S from "./SplashCard.styles";
+import { useState, useEffect } from "react";
+
+export function SplashCard({ ...props }) {
+    const [isCardVisible, setCardVisible] = useState(true);
+
+    useEffect(() => {
+        setTimeout(() => setCardVisible(false), 10000);
+    }, []);
+
+    return (
+        <S.Container style={{ display: `${isCardVisible ? "flex" : "none"}` }}>
+            <LoadingCircle />
+            <S.TextContainer>
+                <S.Desc>
+                    FRONTEND DEVELOPER <br />
+                    Portfolio Website
+                </S.Desc>
+                <S.Name>MayOwall</S.Name>
+            </S.TextContainer>
+        </S.Container>
+    );
+}

--- a/components/features/SplashCard/index.ts
+++ b/components/features/SplashCard/index.ts
@@ -1,0 +1,1 @@
+export { SplashCard } from "./SplashCard";

--- a/components/index.ts
+++ b/components/index.ts
@@ -3,7 +3,15 @@ import { LoadingCircle } from "./atoms/LoadingCircle";
 
 import { MainNavBar } from "./features/MainNavBar";
 import { PageTopper } from "./features/PageTopper";
+import { SplashCard } from "./features/SplashCard";
 
 import { MainTemplate } from "./templates/MainTemplate";
 
-export { OvalNav, MainNavBar, PageTopper, MainTemplate, LoadingCircle };
+export {
+    OvalNav,
+    MainNavBar,
+    PageTopper,
+    MainTemplate,
+    LoadingCircle,
+    SplashCard,
+};

--- a/components/index.ts
+++ b/components/index.ts
@@ -1,8 +1,9 @@
 import { OvalNav } from "./atoms/OvalNav";
+import { LoadingCircle } from "./atoms/LoadingCircle";
 
 import { MainNavBar } from "./features/MainNavBar";
 import { PageTopper } from "./features/PageTopper";
 
 import { MainTemplate } from "./templates/MainTemplate";
 
-export { OvalNav, MainNavBar, PageTopper, MainTemplate };
+export { OvalNav, MainNavBar, PageTopper, MainTemplate, LoadingCircle };

--- a/components/templates/MainTemplate/MainTemplate.tsx
+++ b/components/templates/MainTemplate/MainTemplate.tsx
@@ -1,9 +1,10 @@
-import { PageTopper, MainNavBar } from "components";
+import { PageTopper, MainNavBar, SplashCard } from "components";
 import * as S from "./MainTemplate.styles";
 
 export function MainTemplate({ ...props }) {
     return (
         <S.Container>
+            <SplashCard />
             <PageTopper>
                 <MainNavBar />
             </PageTopper>

--- a/components/templates/MainTemplate/MainTemplate.tsx
+++ b/components/templates/MainTemplate/MainTemplate.tsx
@@ -1,10 +1,35 @@
+import { useState, useEffect } from "react";
 import { PageTopper, MainNavBar, SplashCard } from "components";
 import * as S from "./MainTemplate.styles";
 
 export function MainTemplate({ ...props }) {
+    const [isSplashCardVisible, setSplashCardVisible] = useState(false);
+
+    useEffect(() => {
+        const splashCardDate = Number(
+            window.localStorage.getItem("splashCardDate")
+        );
+
+        if (!splashCardDate) {
+            setSplashCardVisible(true);
+            window.localStorage.setItem(
+                "splashCardDate",
+                String(Date.now() + 60000)
+            );
+        } else {
+            const current = Date.now();
+            if (current > splashCardDate) {
+                setSplashCardVisible(true);
+                window.localStorage.setItem(
+                    "splashCardDate",
+                    String(Date.now() + 60000)
+                );
+            }
+        }
+    }, []);
     return (
         <S.Container>
-            <SplashCard />
+            {isSplashCardVisible ? <SplashCard /> : null}
             <PageTopper>
                 <MainNavBar />
             </PageTopper>


### PR DESCRIPTION
## 설명

### 스플래시 스크린 구현

#### 314f6d23bec0b6e901545a3ce9ba5d7132e7aa9e 

LoadingCircle atom 컴포넌트 구현

<img width="400" alt="image" src="https://user-images.githubusercontent.com/97934878/196391322-cebc2cf4-f985-47c9-bcc6-c440011f36e5.png">

<br>

#### 9475f4114e2a6c10562e7814c5c689e26f68cc79

SplashCard feature 컴포넌트 구현

<img width="400" alt="image" src="https://user-images.githubusercontent.com/97934878/196391465-068b4eb2-d6fc-4bc0-b329-3a36d476bd9d.png">

<br>

#### 9475f4114e2a6c10562e7814c5c689e26f68cc79

SplashCard를 MainTemplate에 삽입

<br>

#### 8ffb2396ca7fc91a4212c5a24d0c839814eabaa0

LocalStorage를 통한 SplashCard 유효기간 설정

<br>
<br>

